### PR TITLE
fix: shim localStorage/sessionStorage in vitest setup

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,41 @@
 import '@testing-library/jest-dom'
 
+// Node ≥22 ships an experimental `localStorage`/`sessionStorage` global that shadows
+// jsdom's polyfill with a non-functional object (no getItem/setItem). Replace it
+// with an in-memory Storage shim so hooks that touch web storage work in tests.
+const createStorageShim = (): Storage => {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) =>
+      store.has(key) ? (store.get(key) as string) : null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+  }
+}
+
+for (const name of ['localStorage', 'sessionStorage'] as const) {
+  const shim = createStorageShim()
+  Object.defineProperty(globalThis, name, {
+    value: shim,
+    configurable: true,
+    writable: true,
+  })
+  Object.defineProperty(window, name, {
+    value: shim,
+    configurable: true,
+    writable: true,
+  })
+}
+
 // Mock IntersectionObserver
 ;(
   globalThis as typeof globalThis & { IntersectionObserver?: unknown }


### PR DESCRIPTION
## Summary

All 3 unit tests have been failing on `main` due to a Node ≥22 + jsdom interaction:
Node ships an experimental `localStorage` global without the full `Storage` interface (no `getItem`/`setItem`), which shadows jsdom's polyfill in vitest. `usePalette` reads `localStorage.getItem(PALETTE_KEY)` at mount, so PaletteSelector throws before render.

Fix: replace `localStorage` and `sessionStorage` on both `globalThis` and `window` in the vitest setup with an in-memory `Storage` shim that implements the full interface.

## Test plan
- [x] `npm run test:unit` — 3/3 passing locally (was 0/3 before)
- [x] `npm run lint` — clean
- [x] `npm run type-check` — clean