### PR TITLE
docs: rewrite CI-CD.md and TROUBLESHOOTING.md for Dokploy deploy

### DIFF
--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -1,355 +1,344 @@
-# 📚 Documentación del Sistema CI/CD Automático
+# 📚 Documentación del Sistema CI/CD
 
-Este documento describe el sistema de integración y despliegue continuo (CI/CD) configurado para el portfolio de Alejandro de la Fuente.
+Este documento describe el pipeline real de integración y despliegue continuo del portfolio de Alejandro de la Fuente.
 
 ## 🎯 Resumen Ejecutivo
 
-El sistema automatiza completamente el proceso desde el desarrollo hasta la producción, garantizando calidad y desplegando automáticamente cambios validados en tellmealex.com.
+El sistema separa validación (GitHub Actions) y despliegue (Dokploy). GitHub Actions ejecuta los quality gates y notifica el estado; Dokploy escucha el webhook de GitHub y orquesta el build + despliegue del contenedor Docker en el VPS de producción. Traefik (incluido en Dokploy) termina TLS y enruta el tráfico hacia el contenedor.
 
 ## 🏗️ Arquitectura General
 
 ```mermaid
 graph TB
-    DEV[👨‍💻 Desarrollador] --> GIT[📁 Git Push main]
-    GIT --> GHA[🤖 GitHub Actions]
+    DEV[👨‍💻 Desarrollador] --> GIT[📁 git push origin main]
+    GIT --> GHA[🤖 GitHub Actions<br/>ci-cd.yml]
 
-    subgraph "CI/CD Pipeline"
-        GHA --> QC[🔍 Quality Checks]
-        QC --> SC[🛡️ Security Scan]
-        SC --> BT[🏗️ Build Test]
-        BT --> DT[🚀 Deployment Trigger]
+    subgraph "Quality Gates (GitHub Actions)"
+        GHA --> QC[🔍 Lint / Format / Type-check]
+        QC --> TST[🧪 Unit Tests + Coverage]
+        TST --> SC[🛡️ npm audit]
+        SC --> BT[🏗️ Build Verification]
+        BT --> NOTIF[📣 dokploy-deploy.yml<br/>Notification]
     end
 
-    DT --> SSH[📡 SSH Deployment]
+    GIT -. webhook .-> DOK[🚢 Dokploy<br/>Raspberry Pi]
 
-    subgraph "Servidor (198.12.82.184)"
-        SSH --> CONT[🐳 react-nginx-app]
-        CONT --> WEB[🌐 tellmealex.com]
+    subgraph "Dokploy Pipeline"
+        DOK --> BUILD[🐳 Docker multi-stage build]
+        BUILD --> SWARM[🐝 Docker Swarm<br/>portfolio-portfolioapp-cjgywg]
     end
 
+    SWARM --> TRAEFIK[🌐 Traefik<br/>SSL termination]
+    TRAEFIK --> WEB[🔗 https://tellmealex.dev]
     WEB --> USER[👥 Usuarios]
 ```
 
-## 📋 Flujo Detallado del Proceso
+> **Nota**: GitHub Actions y Dokploy operan en paralelo a partir del mismo evento `push`. El deploy _no_ depende del éxito de los quality gates — si los tests fallan, lo que llega a producción puede seguir construyéndose. Si quieres bloquear deploys ante fallos de CI, configura una branch protection rule que exija `ci-cd.yml` como check antes de poder mergear a `main`.
 
-### 1. Desarrollo y Commit
+## 📋 Flujo Detallado
+
+### 1. Push a `main`
 
 ```mermaid
 sequenceDiagram
     participant Dev as 👨‍💻 Desarrollador
-    participant Git as 📁 Git Repository
+    participant Git as 📁 GitHub
     participant GHA as 🤖 GitHub Actions
+    participant DOK as 🚢 Dokploy
 
     Dev->>Git: git push origin main
-    Git->>GHA: Trigger CI/CD Pipeline
-    Note over GHA: Workflow: ci-cd.yml
+    Git->>GHA: Dispara ci-cd.yml
+    Git-->>DOK: Webhook (GitHub App)
+    Note over GHA,DOK: Ambos flujos arrancan en paralelo
 ```
 
-### 2. Pipeline de Calidad (CI/CD)
+### 2. Pipeline de Validación (`ci-cd.yml`)
 
 ```mermaid
 graph LR
-    subgraph "Quality Checks (~28s)"
-        QC1[📦 npm install]
+    subgraph "Job: quality-checks"
+        QC1[📦 npm ci]
         QC2[✨ npm run lint]
         QC3[🎨 npm run format:check]
         QC4[🔍 npm run type-check]
-        QC5[🧪 npm run test:unit]
-        QC1 --> QC2 --> QC3 --> QC4 --> QC5
+        QC5[🧪 npm run test:unit --coverage]
+        QC6[📊 Upload Codecov]
+        QC1 --> QC2 --> QC3 --> QC4 --> QC5 --> QC6
     end
 
-    subgraph "Security Scan (~16s)"
-        SC1[📦 npm install]
-        SC2[🛡️ npm audit]
+    subgraph "Job: security-scan"
+        SC1[📦 npm ci]
+        SC2[🛡️ npm audit --audit-level moderate]
         SC1 --> SC2
     end
 
-    subgraph "Build Test (~21s)"
-        BT1[📦 npm install]
+    subgraph "Job: build-test"
+        BT1[📦 npm ci]
         BT2[🏗️ npm run build]
         BT1 --> BT2
     end
 
-    QC5 --> SC1
+    subgraph "Job: deployment-notification"
+        DN1[✅ Reporta estado]
+    end
+
+    QC6 --> SC1
     SC2 --> BT1
-    BT2 --> DT[🚀 Deployment Trigger]
+    BT2 --> DN1
 ```
 
-### 3. Despliegue SSH Automático
+**Workflow file**: [.github/workflows/ci-cd.yml](../.github/workflows/ci-cd.yml)
+
+Jobs en orden:
+
+1. `quality-checks` — instala con `npm ci`, ejecuta lint, format check, type-check, tests con cobertura, sube coverage a Codecov.
+2. `security-scan` — `npm audit --audit-level moderate` (continue-on-error: true; informa pero no bloquea).
+3. `build-test` — verifica que `npm run build` termina sin errores.
+4. `deployment-notification` — solo si el push es a `main`: imprime un resumen indicando que Dokploy se encargará del deploy.
+
+### 3. Notificación de Deploy (`dokploy-deploy.yml`)
 
 ```mermaid
 sequenceDiagram
-    participant GHA as 🤖 GitHub Actions
-    participant SSH as 📡 SSH Connection
-    participant Server as 🖥️ Servidor
-    participant Docker as 🐳 Container
-    participant Web as 🌐 Website
+    participant GHA as 🤖 ci-cd.yml
+    participant DN as 📣 dokploy-deploy.yml
+    participant Dev as 👨‍💻 Desarrollador
 
-    GHA->>SSH: Establecer conexión SSH
-    SSH->>Server: mkdir -p /root/development/portfolio
-    SSH->>Server: scp dist/* → servidor
-    SSH->>Docker: docker exec react-nginx-app
-    Docker->>Docker: Backup contenido actual
-    Docker->>Docker: rm -rf /usr/share/nginx/html/*
-    SSH->>Docker: docker cp archivos → container
-    Docker->>Docker: nginx -s reload
-    Docker->>Web: Contenido actualizado
-    SSH->>GHA: ✅ Deployment exitoso
+    GHA->>DN: workflow_run completed (success)
+    DN->>Dev: Log "✅ Listo para deploy"
+    Note over DN: NO dispara despliegue.<br/>Sirve como recordatorio del estado.
+```
+
+**Workflow file**: [.github/workflows/dokploy-deploy.yml](../.github/workflows/dokploy-deploy.yml)
+
+Este workflow escucha el evento `workflow_run` del CI principal y simplemente registra que el código está listo. El deploy real ocurre vía webhook directo de GitHub → Dokploy, independiente de GitHub Actions.
+
+### 4. Build y Deploy en Dokploy
+
+```mermaid
+sequenceDiagram
+    participant Git as 📁 GitHub
+    participant DOK as 🚢 Dokploy (Raspberry Pi)
+    participant VPS as 🖥️ VPS 198.12.82.184
+    participant SWARM as 🐝 Docker Swarm
+    participant TRAEFIK as 🌐 Traefik
+
+    Git->>DOK: Push webhook (rama main)
+    DOK->>VPS: Clone + docker build (multi-stage)
+    Note over VPS: Stage 1: node:25-slim → npm ci + vite build<br/>Stage 2: nginx:1.29-alpine + dist/
+    VPS->>SWARM: docker service update (rolling)
+    SWARM->>TRAEFIK: Nuevo contenedor saludable
+    TRAEFIK->>TRAEFIK: Renueva/usa cert Let's Encrypt
+    TRAEFIK-->>Git: ✅ https://tellmealex.dev sirviendo nueva versión
 ```
 
 ## 🔧 Componentes Técnicos
 
-### Archivos de Configuración
+### Workflows de GitHub Actions
 
-#### `.github/workflows/ci-cd.yml`
+| Archivo                                                                         | Trigger                                                       | Propósito                                                    |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------ |
+| [.github/workflows/ci-cd.yml](../.github/workflows/ci-cd.yml)                   | `push` y `pull_request` a `main` (`push` también a `develop`) | Quality gates: lint, format, type-check, tests, audit, build |
+| [.github/workflows/dokploy-deploy.yml](../.github/workflows/dokploy-deploy.yml) | `workflow_run` de "CI/CD Pipeline" (success, rama main)       | Notificación informativa de que el deploy está listo         |
+| [.github/workflows/security.yml](../.github/workflows/security.yml)             | Programado / PR                                               | Escaneo de seguridad adicional                               |
+| [.github/workflows/performance.yml](../.github/workflows/performance.yml)       | PR / programado                                               | Métricas de rendimiento (Lighthouse)                         |
+| [.github/workflows/pr-validation.yml](../.github/workflows/pr-validation.yml)   | PR                                                            | Validaciones específicas de pull requests                    |
 
-- **Propósito**: Pipeline principal de validación
-- **Triggers**: Push/PR a rama `main`
-- **Jobs**: quality-checks → security-scan → build-test → deployment-trigger
+### Dockerfile (multi-stage)
 
-#### `.github/workflows/deploy-ssh.yml`
+Ver [Dockerfile](../Dockerfile) para el detalle completo. Resumen:
 
-- **Propósito**: Despliegue automático al servidor
-- **Trigger**: Completion exitosa de ci-cd.yml
-- **Estrategia**: Actualización in-place del container existente
+- **Stage 1 — builder** (`node:25-slim`): instala dependencias del sistema, `npm ci`, type-check, lint (best-effort), `npm run build` con `NODE_ENV=production`.
+- **Stage 2 — runtime** (`nginx:1.29-alpine`): copia `dist/` del builder a `/usr/share/nginx/html`, monta `nginx.conf` propio, ejecuta como usuario `nginx`, expone puerto `80`, healthcheck cada 30 s.
+
+Imagen final ~50 MB. El TLS lo termina Traefik, no Nginx.
 
 ### Stack Tecnológico
 
 ```mermaid
 graph TB
     subgraph "Frontend"
-        REACT[⚛️ React 18]
+        REACT[⚛️ React 19]
         TS[📘 TypeScript]
         VITE[⚡ Vite]
-        TAIL[🎨 Tailwind CSS]
+        CSS[🎨 CSS Modules + Tokens]
     end
 
     subgraph "Quality Tools"
         ESLINT[🔍 ESLint]
         PRETTIER[✨ Prettier]
         VITEST[🧪 Vitest]
-        YARN[📦 Yarn]
+        NPM[📦 npm]
     end
 
-    subgraph "Infrastructure"
-        DOCKER[🐳 Docker]
-        NGINX[🌐 Nginx]
-        SSL[🔒 Let's Encrypt SSL]
-        SSH[📡 SSH]
+    subgraph "Deploy Infrastructure"
+        DOK[🚢 Dokploy]
+        DOCKER[🐳 Docker Swarm]
+        NGINX[🌐 Nginx 1.29-alpine]
+        TRAEFIK[🔒 Traefik + Let's Encrypt]
     end
 
-    REACT --> QUALITY
-    TS --> QUALITY
-    VITE --> QUALITY
-    QUALITY --> DOCKER
-    DOCKER --> NGINX
+    REACT --> VITE
+    VITE --> NPM
+    NPM --> DOCKER
+    DOCKER --> DOK
+    DOK --> NGINX
+    NGINX --> TRAEFIK
 ```
 
-## 🚀 Proceso de Despliegue Detallado
+## 🚀 Estrategia de Despliegue
 
-### Estrategia de Container Update
+Dokploy ejecuta `docker service update` sobre la stack Swarm. La rolling update levanta el nuevo contenedor, espera al healthcheck `HEALTHCHECK CMD curl -f http://localhost/`, y solo entonces drena el anterior. Resultado: zero downtime y rollback trivial desde la UI de Dokploy si el deploy queda en estado unhealthy.
 
-El sistema utiliza una estrategia inteligente que **actualiza el container existente** en lugar de crear uno nuevo:
+### Ventajas de delegar en Dokploy + Traefik
 
-```mermaid
-graph LR
-    subgraph "Antes"
-        OLD[🐳 react-nginx-app<br/>Puerto 80:80, 443:443<br/>SSL Certificates]
-    end
+1. **Zero downtime** vía rolling update de Docker Swarm.
+2. **SSL automático**: Traefik renueva certificados Let's Encrypt sin intervención.
+3. **Rollback con un click** desde la UI de Dokploy a cualquier deploy anterior.
+4. **Sin secrets SSH en GitHub**: el deploy lo orquesta Dokploy hablando con su propio Docker daemon.
+5. **Build aislado**: ocurre dentro del contenedor de Dokploy, no en el runner de GitHub Actions.
 
-    subgraph "Durante Update"
-        BACKUP[💾 Backup contenido]
-        CLEAR[🗑️ Limpiar /html/*]
-        COPY[📄 Copiar nuevos archivos]
-        RELOAD[🔄 nginx -s reload]
-    end
-
-    subgraph "Después"
-        NEW[🐳 react-nginx-app<br/>Puerto 80:80, 443:443<br/>SSL Certificates<br/>✨ Contenido actualizado]
-    end
-
-    OLD --> BACKUP --> CLEAR --> COPY --> RELOAD --> NEW
-```
-
-### Ventajas de esta Estrategia
-
-1. **Zero Downtime**: El container nunca se detiene
-2. **SSL Preservation**: Mantiene certificados Let's Encrypt
-3. **Port Management**: Evita conflictos de puerto 80/443
-4. **Rollback Safety**: Backup automático antes de actualizar
-
-## 📊 Métricas y Tiempos
-
-### Tiempos Promedio de Ejecución
+## 📊 Tiempos Aproximados
 
 ```mermaid
 gantt
-    title Timeline del CI/CD Process
+    title Timeline desde push hasta producción
     dateFormat X
-    axisFormat %s
+    axisFormat %ss
 
-    section CI Pipeline
-    Quality Checks    :0, 28
-    Security Scan     :28, 44
-    Build Test        :44, 65
-    Trigger           :65, 68
+    section GitHub Actions
+    quality-checks            :0, 60
+    security-scan             :60, 75
+    build-test                :75, 100
+    deployment-notification   :100, 105
 
-    section SSH Deploy
-    Setup SSH         :68, 73
-    Deploy to Server  :73, 108
-    Verify            :108, 113
+    section Dokploy (paralelo)
+    docker build              :0, 120
+    docker service update     :120, 165
+    healthcheck + traffic switch :165, 180
 
-    section Total
-    Complete Process  :0, 113
+    section Resultado
+    Live en tellmealex.dev    :180, 185
 ```
 
-**Tiempo Total**: ~2 minutos desde push hasta deployment
+**Tiempo total típico**: ~3 minutos desde push hasta nueva versión sirviendo tráfico.
 
-## 🔒 Configuración de Seguridad
+## 🔒 Seguridad
 
-### GitHub Secrets Requeridos
+### Secrets de GitHub
 
 ```yaml
-SSH_HOST: '198.12.82.184' # IP del servidor
-SSH_USER: 'root' # Usuario SSH
-SSH_PRIVATE_KEY: '-----BEGIN...' # Clave privada SSH
+DOKPLOY_API_TOKEN: <token> # Solo necesario si quieres disparar deploys desde GitHub Actions
 ```
 
-### Validaciones de Seguridad
+Actualmente el deploy lo dispara la GitHub App de Dokploy (`Dokploy-2025-10-23-b1h5vv`), por lo que no es estrictamente necesario almacenar secrets de SSH ni de servidor en GitHub. Los secrets antiguos (`SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`, `RASPBERRY_PI_*`, `TAILSCALE_*`) se pueden eliminar — ver [DOKPLOY-AUTO-DEPLOY-SETUP.md](../DOKPLOY-AUTO-DEPLOY-SETUP.md).
+
+### Validaciones encadenadas
 
 ```mermaid
 graph TD
     CODE[📝 Código] --> LINT[🔍 ESLint]
-    LINT --> AUDIT[🛡️ npm audit]
-    AUDIT --> TYPE[📘 TypeScript]
-    TYPE --> TEST[🧪 Unit Tests]
-    TEST --> BUILD[🏗️ Build Verification]
-    BUILD --> DEPLOY[🚀 Deploy]
+    LINT --> FMT[🎨 Prettier]
+    FMT --> TYPE[📘 TypeScript]
+    TYPE --> TEST[🧪 Vitest]
+    TEST --> AUDIT[🛡️ npm audit]
+    AUDIT --> BUILD[🏗️ Build Verification]
+    BUILD --> DEPLOY[🚢 Dokploy]
 
     LINT -.-> FAIL1[❌ Lint Errors]
-    AUDIT -.-> FAIL2[❌ Security Vulnerabilities]
+    FMT -.-> FAIL2[❌ Format mismatch]
     TYPE -.-> FAIL3[❌ Type Errors]
     TEST -.-> FAIL4[❌ Test Failures]
     BUILD -.-> FAIL5[❌ Build Errors]
 ```
 
-## 📁 Estructura de Archivos
+Solo `quality-checks` y `build-test` bloquean el pipeline. `security-scan` está en `continue-on-error: true`: informa pero no rompe el build.
 
-### En el Repositorio
+## 📁 Estructura Relevante
 
 ```
 portfolio/
 ├── .github/workflows/
-│   ├── ci-cd.yml              # Pipeline principal
-│   └── deploy-ssh.yml         # Despliegue SSH
-├── src/                       # Código fuente React
-├── public/                    # Assets estáticos
-├── docs/                      # Documentación
-├── package.json               # Dependencias y scripts
-├── package-lock.json                  # Lock de dependencias
-├── vite.config.ts            # Configuración Vite
-└── tailwind.config.js        # Configuración Tailwind
+│   ├── ci-cd.yml                 # Pipeline principal de quality gates
+│   ├── dokploy-deploy.yml        # Notificación post-CI
+│   ├── pr-validation.yml         # Checks específicos de PR
+│   ├── security.yml              # Escaneo de seguridad
+│   └── performance.yml           # Lighthouse / métricas
+├── Dockerfile                    # Multi-stage: node:25-slim → nginx:1.29-alpine
+├── nginx.conf                    # Config Nginx (SPA routing, compresión, headers)
+├── DEPLOYMENT.md                 # Guía operativa de deployment
+├── DOKPLOY-AUTO-DEPLOY-SETUP.md  # Setup y estado de la integración con Dokploy
+├── WEBHOOK-SETUP.md              # Configuración del webhook GitHub → Dokploy
+└── docs/
+    ├── CI-CD.md                  # Este documento
+    └── TROUBLESHOOTING.md        # Diagnóstico operativo
 ```
 
-### En el Servidor (Container)
+## 🔄 Rollback
 
-```
-/usr/share/nginx/html/
-├── index.html                 # Aplicación principal
-├── assets/
-│   ├── index-[hash].js       # JavaScript bundle
-│   ├── index-[hash].css      # CSS bundle
-│   └── vendor-[hash].js      # Vendor bundle
-└── vite.svg                  # Assets estáticos
-```
+Rollback se hace desde la UI de Dokploy, no por SSH:
 
-## 🔄 Flujo de Rollback
+1. Acceder a Dokploy (`http://100.122.202.103:3000` vía Tailscale).
+2. **Projects → portfolio → portfolio-app → Deployments**.
+3. Seleccionar el deploy anterior en estado _success_ y pulsar **Redeploy**.
 
-En caso de problemas, el sistema mantiene backups automáticos:
-
-```mermaid
-graph LR
-    ISSUE[🚨 Problema Detectado] --> BACKUP[💾 Localizar Backup]
-    BACKUP --> RESTORE[🔄 Restaurar Contenido]
-    RESTORE --> RELOAD[🔄 nginx -s reload]
-    RELOAD --> VERIFY[✅ Verificar Funcionamiento]
-```
-
-### Comando de Rollback Manual
+Para verificar el resultado:
 
 ```bash
-# Conectar al servidor
-ssh root@198.12.82.184
+# Listar tasks del service Swarm (desde el VPS o vía Tailscale)
+ssh servidor-198 'docker service ps portfolio-portfolioapp-cjgywg --no-trunc | head -5'
 
-# Listar backups disponibles
-ls -la /tmp/backup-*
-
-# Restaurar backup específico
-docker exec react-nginx-app cp -r /tmp/backup-YYYYMMDD-HHMMSS/* /usr/share/nginx/html/
-
-# Recargar nginx
-docker exec react-nginx-app nginx -s reload
+# Confirmar headers de la versión servida
+curl -I https://tellmealex.dev
 ```
 
-## 🎛️ Monitoreo y Debugging
+## 🎛️ Monitoreo y Debug
 
-### Comandos Útiles de Verificación
+### GitHub Actions
 
 ```bash
-# Estado del workflow
 gh run list -R TellMeAlex/portfolio --limit 5
-
-# Logs de deployment fallido
-gh run view [RUN_ID] --log-failed
-
-# Estado del container en servidor
-ssh root@198.12.82.184 "docker ps | grep react-nginx-app"
-
-# Logs del container
-ssh root@198.12.82.184 "docker logs react-nginx-app --tail 20"
-
-# Verificar contenido actual
-ssh root@198.12.82.184 "docker exec react-nginx-app ls -la /usr/share/nginx/html/"
+gh run view <RUN_ID> --log-failed -R TellMeAlex/portfolio
 ```
 
-### Health Checks
+### Dokploy + contenedor
 
-El sistema incluye verificaciones automáticas:
+```bash
+# Estado del service
+ssh servidor-198 'docker service ls | grep portfolio'
 
-```mermaid
-graph TD
-    DEPLOY[🚀 Deploy Complete] --> CHECK1[🔍 Container Status]
-    CHECK1 --> CHECK2[📡 HTTP Response]
-    CHECK2 --> CHECK3[🌐 External Access]
-    CHECK3 --> SUCCESS[✅ Deployment Verified]
+# Tasks (instancias)
+ssh servidor-198 'docker service ps portfolio-portfolioapp-cjgywg --no-trunc'
 
-    CHECK1 -.-> FAIL1[❌ Container Down]
-    CHECK2 -.-> FAIL2[❌ HTTP Error]
-    CHECK3 -.-> FAIL3[❌ External Blocked]
+# Logs en tiempo real
+ssh servidor-198 'docker service logs -f portfolio-portfolioapp-cjgywg --tail 50'
+
+# Logs de Dokploy (build/deploy events)
+ssh servidor-198 'docker service logs dokploy --tail 100 | grep portfolio'
 ```
+
+> Para la UI de Dokploy y el debug profundo, consulta [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).
 
 ## 📈 Beneficios del Sistema
 
 ### Para el Desarrollo
 
-- ✅ **Automatización Completa**: Cero intervención manual
-- ✅ **Calidad Garantizada**: Múltiples gates de validación
-- ✅ **Feedback Inmediato**: Errores detectados en minutos
-- ✅ **Deployment Seguro**: Backup automático y rollback
+- ✅ **Quality gates rápidos**: feedback en ~1.5 min con cobertura subida a Codecov.
+- ✅ **Pre-commit local**: Husky corre lint y format antes del push, evitando fallos triviales en CI.
+- ✅ **Sin scripts custom de deploy**: la build vive en el `Dockerfile`, reproducible localmente.
 
-### Para la Producción
+### Para Producción
 
-- ✅ **Zero Downtime**: Actualizaciones sin interrupciones
-- ✅ **SSL Preservation**: Certificados mantenidos automáticamente
-- ✅ **Performance**: Assets optimizados con Vite
-- ✅ **Monitoring**: Logs y métricas integradas
+- ✅ **Zero downtime** via Docker Swarm rolling updates.
+- ✅ **TLS gestionado** por Traefik (renovación automática).
+- ✅ **Rollback en un click** desde Dokploy.
+- ✅ **Healthchecks** integrados a nivel de contenedor.
 
-### Para el Mantenimiento
+### Para Mantenimiento
 
-- ✅ **Reproducibilidad**: Mismo proceso cada vez
-- ✅ **Trazabilidad**: Logs completos de cada deployment
-- ✅ **Escalabilidad**: Fácil extensión para nuevos ambientes
-- ✅ **Documentación**: Proceso completamente documentado
+- ✅ **Sin secrets de servidor en GitHub** una vez completado el cleanup.
+- ✅ **Trazabilidad** de cada deploy en la UI de Dokploy.
+- ✅ **Build idéntico** local y en producción (mismo `Dockerfile`).
 
 ## 🚦 Estados del Sistema
 
@@ -358,41 +347,28 @@ stateDiagram-v2
     [*] --> Development
     Development --> Push: git push main
     Push --> CI_Running: GitHub Actions
-    CI_Running --> CI_Success: All checks pass
-    CI_Running --> CI_Failed: Quality gates fail
-    CI_Failed --> Development: Fix issues
-    CI_Success --> Deploy_Running: SSH trigger
-    Deploy_Running --> Deploy_Success: Container updated
-    Deploy_Running --> Deploy_Failed: SSH/Docker issues
-    Deploy_Failed --> Investigation: Debug required
-    Deploy_Success --> Production: Live on tellmealex.com
-    Production --> Development: Next iteration
-    Investigation --> Development: Issues resolved
+    Push --> Dokploy_Build: Webhook a Dokploy
+    CI_Running --> CI_Success: Quality gates OK
+    CI_Running --> CI_Failed: Fallo en lint/test/build
+    CI_Failed --> Development: Corregir
+    Dokploy_Build --> Deploying: docker service update
+    Deploying --> Live: Healthcheck OK
+    Deploying --> Deploy_Failed: Healthcheck KO
+    Deploy_Failed --> Investigation
+    Investigation --> Development
+    Live --> Development: Siguiente iteración
 ```
 
 ## 🎯 Próximos Pasos Sugeridos
 
-### Mejoras Potenciales
-
-1. **Monitoring Avanzado**: Integración con Datadog/New Relic
-2. **Testing E2E**: Playwright tests automáticos
-3. **Multiple Environments**: Staging environment
-4. **Performance Metrics**: Core Web Vitals tracking
-5. **Notifications**: Slack/Discord integration
-
-### Escalabilidad
-
-```mermaid
-graph LR
-    CURRENT[🎯 Actual<br/>Single Server] --> STAGING[🔄 Staging<br/>Environment]
-    STAGING --> CDN[📡 CDN<br/>Integration]
-    CDN --> CLUSTER[☁️ Container<br/>Orchestration]
-    CLUSTER --> MONITORING[📊 Advanced<br/>Monitoring]
-```
+1. **Branch protection rule** en `main` exigiendo el check de `ci-cd.yml` antes de mergear, para que los quality gates bloqueen realmente el deploy.
+2. **E2E tests** con Playwright integrados al pipeline.
+3. **Notificaciones**: webhook de Dokploy a Slack/Discord para deploys success/failure.
+4. **Staging environment**: una segunda app en Dokploy apuntando a una rama distinta.
+5. **Limpieza de secrets** legados (SSH, Tailscale, Raspberry Pi) — ver [DOKPLOY-AUTO-DEPLOY-SETUP.md](../DOKPLOY-AUTO-DEPLOY-SETUP.md).
 
 ---
 
-**🎉 Sistema CI/CD Completamente Funcional**
-**📅 Implementado**: Octubre 2025
-**🔗 URL**: https://tellmealex.com
+**🔗 URL producción**: https://tellmealex.dev
 **📧 Contacto**: llamamealex@gmail.com
+**📅 Última revisión**: 2026-05-23

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # 🔧 Guía de Troubleshooting CI/CD
 
-Esta guía te ayudará a diagnosticar y resolver problemas comunes en el sistema CI/CD.
+Esta guía cubre el diagnóstico del pipeline actual: GitHub Actions (quality gates) + Dokploy (build y deploy del contenedor) + Traefik (TLS). Para la arquitectura completa, ver [CI-CD.md](./CI-CD.md).
 
 ## 🚨 Problemas Comunes y Soluciones
 
@@ -18,7 +18,7 @@ Esta guía te ayudará a diagnosticar y resolver problemas comunes en el sistema
 **Diagnóstico:**
 
 ```bash
-# Ejecutar localmente para reproducir
+# Reproduce los gates localmente
 npm run lint
 npm run format:check
 npm run type-check
@@ -28,335 +28,245 @@ npm run test:unit
 **Soluciones:**
 
 ```bash
-# Fix linting issues
+# Fix linting
 npm run lint -- --fix
 
 # Fix formatting
 npm run format
 
-# Fix TypeScript errors
-# Revisar errores específicos en el output
-
 # Debug tests
 npm run test:unit -- --reporter=verbose
 ```
 
-#### ❌ Security Scan Fallando
+#### ❌ Security Scan con Vulnerabilidades
 
-**Síntomas:**
-
-- npm audit encuentra vulnerabilidades
-- Dependencias con problemas de seguridad
-
-**Diagnóstico:**
+`security-scan` corre `npm audit --audit-level moderate` con `continue-on-error: true`: informa pero **no** bloquea el build. Aun así, conviene resolver hallazgos.
 
 ```bash
-# Revisar vulnerabilidades
 npm audit
-
-# Ver detalles específicos
 npm audit --audit-level=moderate
-```
-
-**Soluciones:**
-
-```bash
-# Actualizar dependencias vulnerables
 npm audit fix
-
-# Actualizar dependencias específicas
-npm update [package-name]
-
-# En casos críticos, considerar alternativas
-npm uninstall [vulnerable-package]
-npm install [alternative-package]
+npm update <package-name>
 ```
 
 #### ❌ Build Test Fallando
 
 **Síntomas:**
 
-- `npm run build` falla
-- Assets no se generan correctamente
+- `npm run build` falla en CI o en Dokploy
 - Import/export errors
+- Errores de Vite/Rollup
 
 **Diagnóstico:**
 
 ```bash
-# Construir localmente
 npm run build
-
-# Revisar configuración Vite
-cat vite.config.ts
-
-# Verificar imports
 npm run type-check
 ```
 
 **Soluciones:**
 
 ```bash
-# Limpiar caché y reconstruir
+# Limpieza completa
 rm -rf dist/ node_modules/
 npm install
 npm run build
 
-# Verificar rutas de importación
-# Verificar configuración de Vite
-# Verificar estructura de archivos
+# Probar la build idéntica a producción (multi-stage Docker)
+docker build -t portfolio:test .
+docker run --rm -p 8080:80 portfolio:test
+curl -I http://localhost:8080
 ```
 
-### 2. SSH Deployment Fallando
+> Si el build pasa en local pero falla en Dokploy, casi siempre es un problema de variables de entorno o de versión de Node. El [Dockerfile](../Dockerfile) usa `node:25-slim`; aliñar `nvm use 20+` en local si difiere.
 
-#### ❌ SSH Connection Issues
+---
 
-**Síntomas:**
+### 2. Dokploy / Webhook Deployment
 
-- "Permission denied"
-- "Connection refused"
-- "Host key verification failed"
+#### ❌ Push a main pero Dokploy no construye
+
+**Síntomas:** GitHub Actions termina OK pero no aparece un nuevo deployment en la UI de Dokploy, y la web sigue sirviendo la versión anterior.
 
 **Diagnóstico:**
 
 ```bash
-# Probar conexión SSH manual
-ssh -i ~/.ssh/servidor_198_12_82_184 root@198.12.82.184
+# 1. ¿Existe el webhook configurado en GitHub?
+gh api repos/TellMeAlex/portfolio/hooks --jq '.[] | {url: .config.url, active: .active, events: .events}'
 
-# Verificar secrets en GitHub
-# Settings > Secrets and variables > Actions
+# 2. ¿Está la GitHub App de Dokploy instalada y con acceso al repo?
+gh api /repos/TellMeAlex/portfolio/installation 2>/dev/null | jq '.app_slug, .permissions'
+
+# 3. Recent deliveries del webhook (200 OK = bien, 5xx/timeout = mal)
+#    GitHub UI: Settings → Webhooks → [webhook] → Recent Deliveries
 ```
 
-**Soluciones:**
+**Causas frecuentes:**
 
-1. **Verificar SSH Secrets en GitHub:**
-   - `SSH_HOST`: `198.12.82.184`
-   - `SSH_USER`: `root`
-   - `SSH_PRIVATE_KEY`: clave completa incluyendo `-----BEGIN...-----END`
+| Causa                              | Cómo se ve                             | Solución                                                                                                    |
+| ---------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| GitHub App revocada o sin permisos | "Recent Deliveries" vacío o 403        | Reinstalar `Dokploy-2025-10-23-b1h5vv` con acceso al repo                                                   |
+| Dokploy no alcanzable desde GitHub | Recent Deliveries con timeout / 5xx    | Verificar reverse proxy (Traefik) que expone la API de Dokploy; ver [WEBHOOK-SETUP.md](../WEBHOOK-SETUP.md) |
+| Auto-deploy desactivado en Dokploy | Webhook responde 200 pero no construye | UI de Dokploy → portfolio-app → Source → habilitar "Auto Deploy" en rama `main`                             |
+| Rama distinta a `main`             | Push a `develop` no dispara nada       | Es el comportamiento esperado; el webhook solo escucha `main`                                               |
 
-2. **Regenerar SSH Keys si es necesario:**
+**Fix manual (forzar deploy ahora):**
 
-```bash
-# En tu máquina local
-ssh-keygen -t rsa -b 4096 -f ~/.ssh/servidor_198_12_82_184_new
+1. Acceder a Dokploy: `http://100.122.202.103:3000` (vía Tailscale).
+2. **Projects → portfolio → portfolio-app**.
+3. Click **Deploy**. Dokploy clonará el último commit de `main` y construirá.
 
-# Copiar clave pública al servidor
-ssh-copy-id -i ~/.ssh/servidor_198_12_82_184_new.pub root@198.12.82.184
+#### ❌ Deploy iniciado pero falla en build
 
-# Actualizar secret en GitHub con la nueva clave privada
-```
-
-#### ❌ Docker Container Issues
-
-**Síntomas:**
-
-- Container no existe: `react-nginx-app`
-- Docker commands failing
-- Port conflicts
+**Síntomas:** Dokploy muestra el deploy en estado `failed` o `error` en la pestaña Deployments.
 
 **Diagnóstico:**
 
 ```bash
-# Conectar al servidor
-ssh root@198.12.82.184
+# Logs de la build (desde el VPS o vía Tailscale)
+ssh servidor-198 'docker service logs dokploy --tail 200 | grep -i portfolio'
 
-# Verificar containers
-docker ps -a
-
-# Verificar logs
-docker logs react-nginx-app
-
-# Verificar puertos
-netstat -tulpn | grep :80
+# Inspeccionar el log del deploy concreto desde la UI:
+#   portfolio-app → Deployments → [click en el fallido] → View Logs
 ```
 
-**Soluciones:**
+**Causas frecuentes:**
 
-1. **Si el container no existe:**
+- **Dependencias rotas**: `npm ci` falla porque `package-lock.json` y `package.json` no concuerdan. Reproducir local con `rm -rf node_modules && npm ci`.
+- **Type errors**: el Dockerfile corre `npm run type-check` en el builder; si falla allí, falla todo. Correr local primero.
+- **OOM en la Raspberry Pi**: si Dokploy se queda sin memoria durante el build de Vite, mover la build al VPS (cambiar el "Build Server" en la config de la app en Dokploy).
 
-```bash
-# Crear container básico temporal
-docker run -d --name react-nginx-app -p 80:80 -p 443:443 nginx:alpine
+#### ❌ Build pasa pero contenedor no arranca (healthcheck failing)
 
-# O restaurar desde backup si existe
-```
-
-2. **Si hay conflictos de puerto:**
-
-```bash
-# Identificar qué está usando el puerto
-lsof -i :80
-
-# Detener proceso conflictivo
-docker stop [container-conflictivo]
-
-# Restart container principal
-docker restart react-nginx-app
-```
-
-#### ❌ File Transfer Issues
-
-**Síntomas:**
-
-- `scp` command failing
-- Files not updating in container
-- Permission denied on file operations
+**Síntomas:** Dokploy completa el build pero el deploy queda en `unhealthy` o reinicia en bucle.
 
 **Diagnóstico:**
 
 ```bash
-# Verificar espacio en disco del servidor
-ssh root@198.12.82.184 "df -h"
+# Estado del service y sus tasks
+ssh servidor-198 'docker service ps portfolio-portfolioapp-cjgywg --no-trunc'
 
-# Verificar permisos del directorio
-ssh root@198.12.82.184 "ls -la /root/development/"
+# Logs del contenedor
+ssh servidor-198 'docker service logs portfolio-portfolioapp-cjgywg --tail 100'
 
-# Verificar contenido actual del container
-ssh root@198.12.82.184 "docker exec react-nginx-app ls -la /usr/share/nginx/html/"
+# Health del contenedor
+ssh servidor-198 'docker inspect $(docker ps -q --filter "name=portfolio-portfolioapp") --format "{{json .State.Health}}" | jq'
 ```
 
-**Soluciones:**
+**Solución:**
 
-1. **Limpiar espacio si es necesario:**
+- Si `nginx` reporta errores de configuración, revisar [nginx.conf](../nginx.conf). El healthcheck es `curl -f http://localhost/`: si la raíz no devuelve 200, el contenedor se marca unhealthy.
+- Rollback inmediato desde Dokploy: **Deployments → [deploy anterior] → Redeploy**.
 
-```bash
-ssh root@198.12.82.184 "
-  docker system prune -f
-  rm -rf /root/development/portfolio/*
-  find /tmp -name 'backup-*' -type d -mtime +7 -delete
-"
-```
-
-2. **Fix permisos:**
-
-```bash
-ssh root@198.12.82.184 "
-  mkdir -p /root/development/portfolio
-  chmod 755 /root/development/portfolio
-"
-```
+---
 
 ### 3. Website Issues
 
-#### ❌ Website No Actualiza
+#### ❌ Sitio web sirve versión antigua tras un deploy aparentemente exitoso
 
-**Síntomas:**
-
-- Deployment exitoso pero contenido antiguo
-- Assets 404
-- JavaScript errors en browser
+**Síntomas:** Dokploy reporta deploy `success`, pero `https://tellmealex.dev` muestra contenido anterior.
 
 **Diagnóstico:**
 
 ```bash
-# Verificar timestamp de archivos en container
-ssh root@198.12.82.184 "docker exec react-nginx-app ls -la /usr/share/nginx/html/"
+# ¿Qué task está sirviendo realmente?
+ssh servidor-198 'docker service ps portfolio-portfolioapp-cjgywg --no-trunc | head -5'
 
-# Verificar logs de nginx
-ssh root@198.12.82.184 "docker logs react-nginx-app --tail 20"
+# Headers de respuesta (last-modified, etag)
+curl -I https://tellmealex.dev
 
-# Test HTTP directo
-curl -I http://tellmealex.com
+# Contenido del index.html servido
+curl -s https://tellmealex.dev | grep -E '<title>|<meta name="version"' | head -5
 ```
 
-**Soluciones:**
+**Causas frecuentes:**
 
-1. **Force reload del container:**
+1. **Caché del navegador**: hard refresh con Ctrl+Shift+R, o probar en incógnito.
+2. **Caché de Traefik / CDN**: comprobar el header `cf-cache-status` (si hay Cloudflare por delante) o reiniciar el servicio de Traefik:
+   ```bash
+   ssh servidor-198 'docker service update --force dokploy-traefik'
+   ```
+3. **Rolling update incompleto**: una task vieja sigue sirviendo. Force redeploy:
+   ```bash
+   ssh servidor-198 'docker service update --force portfolio-portfolioapp-cjgywg'
+   ```
 
-```bash
-ssh root@198.12.82.184 "
-  docker exec react-nginx-app nginx -s reload
-  docker restart react-nginx-app
-"
-```
+#### ❌ SSL / HTTPS Issues
 
-2. **Clear browser cache:**
-
-- Ctrl+Shift+R (hard refresh)
-- Developer tools > Network > Disable cache
-
-3. **Verificar assets:**
-
-```bash
-# Verificar que todos los assets existen
-ssh root@198.12.82.184 "docker exec react-nginx-app find /usr/share/nginx/html -name '*.js' -o -name '*.css'"
-```
-
-#### ❌ SSL/HTTPS Issues
-
-**Síntomas:**
-
-- Certificate warnings
-- Mixed content errors
-- HTTPS redirect not working
+**Síntomas:** Warning de certificado, HTTPS no redirige, mixed content.
 
 **Diagnóstico:**
 
 ```bash
-# Verificar certificados
-ssh root@198.12.82.184 "ls -la /etc/letsencrypt/live/tellmealex.com/"
+# Validar la cadena del certificado desde fuera
+curl -vI https://tellmealex.dev 2>&1 | grep -E 'subject:|issuer:|expire'
 
-# Verificar nginx configuration
-ssh root@198.12.82.184 "docker exec react-nginx-app nginx -T"
+# Logs de Traefik (gestor de Let's Encrypt en Dokploy)
+ssh servidor-198 'docker service logs dokploy-traefik --tail 100 | grep -iE "acme|cert|tellmealex"'
 ```
 
 **Soluciones:**
 
-1. **Renovar certificados SSL:**
+El TLS lo gestiona **Traefik dentro de Dokploy**, no certbot ni `/etc/letsencrypt`. Para renovar o regenerar:
 
-```bash
-ssh root@198.12.82.184 "certbot renew --nginx"
-```
+1. **UI de Dokploy → portfolio-app → Domains**.
+2. Verificar que el dominio `tellmealex.dev` está listado con certResolver `letsencrypt`.
+3. Si el cert no se ha emitido (Traefik error en logs):
+   - Confirmar que el DNS `A` de `tellmealex.dev` apunta al VPS (`198.12.82.184`).
+   - Confirmar que el puerto 80 está abierto en el firewall del VPS (Let's Encrypt HTTP-01 challenge).
+   - En la UI de Dokploy: **Redeploy** la app para forzar un nuevo challenge.
+4. Si quieres forzar el flujo manualmente:
+   ```bash
+   # Reiniciar Traefik fuerza el reintento del ACME challenge
+   ssh servidor-198 'docker service update --force dokploy-traefik'
+   ```
 
-2. **Verificar configuración nginx para HTTPS:**
-
-```bash
-# La configuración debe incluir SSL redirects
-# Verificar que los certificados estén montados correctamente
-```
+---
 
 ## 🔍 Comandos de Diagnóstico
 
 ### GitHub Actions
 
 ```bash
-# Ver últimos workflows
 gh run list -R TellMeAlex/portfolio --limit 10
-
-# Ver detalles de un workflow específico
-gh run view [RUN_ID] -R TellMeAlex/portfolio
-
-# Ver logs de error
-gh run view [RUN_ID] --log-failed -R TellMeAlex/portfolio
-
-# Re-ejecutar workflow fallido
-gh run rerun [RUN_ID] -R TellMeAlex/portfolio
+gh run view <RUN_ID> -R TellMeAlex/portfolio
+gh run view <RUN_ID> --log-failed -R TellMeAlex/portfolio
+gh run rerun <RUN_ID> -R TellMeAlex/portfolio
 ```
 
-### Servidor
+### Dokploy (API + UI)
 
 ```bash
-# Estado general del sistema
-ssh root@198.12.82.184 "
-  uptime
-  df -h
-  free -h
-  docker ps
-"
+# Listar deployments de la app vía API (requiere DOKPLOY_API_TOKEN)
+curl -H "x-api-key: $DOKPLOY_API_TOKEN" \
+  http://100.122.202.103:3000/api/application/portfolio-app/deployments | jq
 
-# Logs del container
-ssh root@198.12.82.184 "docker logs react-nginx-app --tail 50"
-
-# Verificar conectividad
-ssh root@198.12.82.184 "curl -I http://localhost"
-
-# Verificar procesos en puertos importantes
-ssh root@198.12.82.184 "netstat -tulpn | grep -E ':(80|443|22)'"
+# Logs del servicio Dokploy en el VPS
+ssh servidor-198 'docker service logs dokploy --tail 200 | grep -i portfolio'
 ```
 
-### Local Development
+### Contenedor en producción
 
 ```bash
-# Verificar que todo funciona localmente
+# Lista de services de la stack portfolio
+ssh servidor-198 'docker service ls | grep portfolio'
+
+# Detalle de las tasks (instancias) del service
+ssh servidor-198 'docker service ps portfolio-portfolioapp-cjgywg --no-trunc'
+
+# Logs en tiempo real
+ssh servidor-198 'docker service logs -f portfolio-portfolioapp-cjgywg --tail 100'
+
+# Inspeccionar configuración del service (imagen, networks, labels Traefik)
+ssh servidor-198 'docker service inspect portfolio-portfolioapp-cjgywg --pretty'
+
+# Verificar el sitio desde el propio VPS (sin pasar por DNS público)
+ssh servidor-198 'curl -I http://localhost'
+```
+
+### Desarrollo local
+
+```bash
 npm install
 npm run lint
 npm run type-check
@@ -364,51 +274,68 @@ npm run test:unit
 npm run build
 npm run preview
 
-# Verificar git status
-git status
-git log --oneline -5
+# Build idéntica a producción
+docker build -t portfolio:local .
+docker run --rm -p 8080:80 portfolio:local
 ```
 
-## 🚨 Emergency Procedures
+---
+
+## 🚨 Procedimientos de Emergencia
 
 ### 1. Rollback Rápido
 
-```bash
-# Conectar al servidor
-ssh root@198.12.82.184
-
-# Listar backups disponibles
-ls -la /tmp/backup-*
-
-# Restaurar último backup bueno
-LAST_BACKUP=$(ls -t /tmp/backup-* | head -1)
-docker exec react-nginx-app cp -r $LAST_BACKUP/* /usr/share/nginx/html/
-docker exec react-nginx-app nginx -s reload
+```mermaid
+graph LR
+    A[🚨 Deploy roto] --> B[Dokploy UI]
+    B --> C[Deployments tab]
+    C --> D[Último deploy verde]
+    D --> E[Click Redeploy]
+    E --> F[✅ Versión anterior live]
 ```
 
-### 2. Restart Completo del Container
+Pasos:
+
+1. Acceder a Dokploy (`http://100.122.202.103:3000`).
+2. **Projects → portfolio → portfolio-app → Deployments**.
+3. Localizar el último deploy `success` previo al fallo.
+4. Click **Redeploy** sobre él.
+5. Verificar con `curl -I https://tellmealex.dev`.
+
+### 2. Force Update del Contenedor
+
+Si el contenedor está vivo pero sirve mal (e.g. healthcheck flake-y):
 
 ```bash
-ssh root@198.12.82.184 "
-  docker restart react-nginx-app
-  sleep 5
-  docker ps | grep react-nginx-app
-  curl -I http://localhost
-"
+ssh servidor-198 'docker service update --force portfolio-portfolioapp-cjgywg'
 ```
 
-### 3. Bypass CI/CD (Emergency Only)
+Esto fuerza una rolling update con la misma imagen. Útil cuando un contenedor queda en un estado degradado pero la imagen es correcta.
+
+### 3. Deploy Manual desde la UI
+
+Si el webhook está caído y necesitas desplegar ya:
+
+1. Dokploy UI → portfolio-app → **Deploy**.
+2. Dokploy clona el último commit de la rama configurada (`main`) y construye.
+3. No requiere acción en GitHub.
+
+### 4. Bypass Total (sin Dokploy)
+
+> ⚠️ **Solo emergencias**. Saltarse Dokploy significa que la próxima vez que Dokploy haga deploy revertirá tus cambios.
 
 ```bash
-# SOLO EN EMERGENCIAS - Deployment manual directo
-npm run build
-scp -r dist/* root@198.12.82.184:/tmp/emergency-deploy/
-ssh root@198.12.82.184 "
-  docker exec react-nginx-app cp -r /tmp/emergency-deploy/* /usr/share/nginx/html/
-  docker exec react-nginx-app nginx -s reload
-  rm -rf /tmp/emergency-deploy
-"
+# Construir la imagen localmente y subirla al VPS
+docker build -t portfolio:emergency .
+docker save portfolio:emergency | ssh servidor-198 'docker load'
+
+# Actualizar el service para usar la imagen local
+ssh servidor-198 'docker service update --image portfolio:emergency portfolio-portfolioapp-cjgywg'
 ```
+
+Recuerda: en cuanto soluciones el problema real, dispara un deploy normal por Dokploy para restablecer el estado canónico.
+
+---
 
 ## 📊 Health Check Script
 
@@ -416,52 +343,64 @@ Guarda este script como `scripts/health-check.sh`:
 
 ```bash
 #!/bin/bash
+set -u
+
 echo "🔍 Sistema CI/CD Health Check"
 echo "=============================="
 
-# 1. GitHub Actions Status
-echo "📊 GitHub Actions Status:"
+# 1. GitHub Actions
+echo -e "\n📊 GitHub Actions (últimos 3 runs):"
 gh run list -R TellMeAlex/portfolio --limit 3
 
-# 2. Server Connectivity
-echo -e "\n🌐 Server Connectivity:"
-if ssh -o ConnectTimeout=10 root@198.12.82.184 "echo 'SSH OK'"; then
-    echo "✅ SSH Connection: OK"
-else
-    echo "❌ SSH Connection: FAILED"
-fi
+# 2. Webhook de GitHub
+echo -e "\n🪝 Webhooks configurados en el repo:"
+gh api repos/TellMeAlex/portfolio/hooks \
+  --jq '.[] | "\(.config.url) (active=\(.active))"'
 
-# 3. Container Status
-echo -e "\n🐳 Container Status:"
-ssh root@198.12.82.184 "docker ps --filter name=react-nginx-app --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'"
+# 3. Service en Docker Swarm
+echo -e "\n🐝 Estado del Docker service:"
+ssh -o ConnectTimeout=10 servidor-198 \
+  'docker service ls --filter name=portfolio --format "table {{.Name}}\t{{.Replicas}}\t{{.Image}}"'
 
-# 4. Website Status
-echo -e "\n🌐 Website Status:"
-HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://tellmealex.com || echo "000")
+# 4. Tasks (instancias)
+echo -e "\n📦 Tasks activas:"
+ssh servidor-198 \
+  'docker service ps portfolio-portfolioapp-cjgywg --filter desired-state=running --no-trunc | head -3'
+
+# 5. Sitio web
+echo -e "\n🌐 Sitio web:"
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://tellmealex.dev || echo "000")
 if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "301" ]; then
-    echo "✅ Website: OK (HTTP $HTTP_STATUS)"
+    echo "✅ tellmealex.dev: OK (HTTP $HTTP_STATUS)"
 else
-    echo "❌ Website: FAILED (HTTP $HTTP_STATUS)"
+    echo "❌ tellmealex.dev: FAILED (HTTP $HTTP_STATUS)"
 fi
 
-# 5. Recent Deployments
-echo -e "\n📈 Recent Deployments:"
-ssh root@198.12.82.184 "docker exec react-nginx-app ls -la /usr/share/nginx/html/ | head -5"
+# 6. Certificado SSL
+echo -e "\n🔒 Certificado SSL:"
+echo | openssl s_client -servername tellmealex.dev -connect tellmealex.dev:443 2>/dev/null \
+  | openssl x509 -noout -dates -issuer
 
 echo -e "\n✅ Health check complete!"
 ```
 
-## 📞 Contacto y Escalación
+---
 
-Si los problemas persisten después de seguir esta guía:
+## 📞 Escalación
 
-1. **Revisar logs completos** de GitHub Actions y server
-2. **Documentar el problema** con screenshots y logs
-3. **Verificar** que no hay cambios en infraestructura externa
-4. **Considerar** si el problema requiere intervención manual urgente
+Si tras seguir esta guía el problema persiste:
+
+1. **Capturar logs**:
+   - GitHub Actions: `gh run view <RUN_ID> --log-failed > ci-failure.log`
+   - Dokploy: `ssh servidor-198 'docker service logs dokploy --tail 500' > dokploy.log`
+   - Contenedor: `ssh servidor-198 'docker service logs portfolio-portfolioapp-cjgywg --tail 500' > app.log`
+2. **Confirmar estado externo**: DNS de `tellmealex.dev`, accesibilidad del VPS, certificado actual.
+3. **Reproducir local** con `docker build` + `docker run` para descartar problemas de código vs problemas de infra.
+4. Documentar pasos seguidos antes de pedir ayuda — tres cuartas partes del troubleshooting es saber exactamente qué se intentó.
 
 ---
 
-**📅 Última actualización**: Octubre 2025
+**📅 Última actualización**: 2026-05-23
 **🔗 Documentación CI/CD**: [CI-CD.md](./CI-CD.md)
+**🔗 Setup de Dokploy**: [DOKPLOY-AUTO-DEPLOY-SETUP.md](../DOKPLOY-AUTO-DEPLOY-SETUP.md) · [WEBHOOK-SETUP.md](../WEBHOOK-SETUP.md)
 **📧 Contacto**: llamamealex@gmail.com


### PR DESCRIPTION
## Summary

Reopens [#88](https://github.com/TellMeAlex/portfolio/pull/88) (auto-closed when base branch was deleted after #86 merge). Rebased clean onto main.

Both docs were written before the SSH→Dokploy deploy migration and still described the old `scp dist/* root@198.12.82.184` + `docker exec react-nginx-app` flow.

Current pipeline:
- **GitHub Actions** (`ci-cd.yml`): quality gates (lint, format, type-check, tests, audit, build) — notification only.
- **Dokploy webhook**: receives push event in parallel, runs the Docker multi-stage build, deploys to Swarm.
- **Traefik** (inside Dokploy): handles SSL termination and routing to the container.

## Changes
- `docs/CI-CD.md`: replaced SSH deployment diagrams/prose with the actual Dokploy pipeline. Notes that GH Actions and Dokploy run in parallel off the same push event — recommends branch protection if blocking deploys on test failure is desired.
- `docs/TROUBLESHOOTING.md`: dropped the entire SSH/`react-nginx-app` section, replaced with Dokploy-specific troubleshooting (webhook delivery, Dokploy UI logs, Traefik certs). References `DOKPLOY-AUTO-DEPLOY-SETUP.md` and `WEBHOOK-SETUP.md`.
- Removed dead references to `/etc/letsencrypt/live/tellmealex.com` (Traefik manages SSL now).

## Test plan
- [x] No code changes — docs only
- [ ] Visual review of mermaid diagrams in GitHub