### PR TITLE
fix: dependabot PR validation + scope ignored majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,14 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@types/react-dom'
         update-types: ['version-update:semver-major']
+      # eslint v10 not yet supported by eslint-plugin-react (peer dep max ^9)
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@eslint/js'
+        update-types: ['version-update:semver-major']
+      # @types/node 25+ ships experimental localStorage that broke jsdom tests
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -83,7 +91,7 @@ updates:
       time: '08:00'
     open-pull-requests-limit: 2
     commit-message:
-      prefix: 'docker'
+      prefix: 'chore'
       include: 'scope'
     labels:
       - 'docker'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 env:
   NODE_VERSION: '20.x'
 
@@ -27,23 +31,30 @@ jobs:
             perf
             test
             chore
+            ci
+            build
           requireScope: false
 
       - name: Check PR size
         uses: actions/github-script@v8
+        continue-on-error: true
         with:
           script: |
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
+            try {
+              const { data: files } = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+              });
 
-            const filesChanged = files.length;
-            if (filesChanged > 20) {
-              core.setFailed(`❌ PR is too large (${filesChanged} files). Consider breaking it down.`);
-            } else {
-              console.log(`✅ PR size is acceptable (${filesChanged} files)`);
+              const filesChanged = files.length;
+              if (filesChanged > 20) {
+                core.warning(`PR is large (${filesChanged} files). Consider breaking it down.`);
+              } else {
+                console.log(`PR size is acceptable (${filesChanged} files)`);
+              }
+            } catch (e) {
+              console.log(`PR size check skipped (likely token permissions): ${e.message}`);
             }
 
   # Code quality analysis


### PR DESCRIPTION
## Summary

Three follow-ups after #86 — necessary so the grouped Dependabot PRs (#89-#94) can land cleanly.

## Changes

### `pr-validation.yml`
- Add `permissions: { contents: read, pull-requests: read }` so the `Check PR size` step (uses `github-script` + `pulls.listFiles`) doesn't 401 on Dependabot PRs. Their default token is read-only without explicit grant.
- Wrap the API call in `try/catch` with `continue-on-error` and downgrade failures to warnings — file-count is advisory, not a hard gate.
- Add `ci` and `build` to allowed semantic-PR title types so `ci(deps):` prefix Dependabot uses for GH Actions bumps doesn't fail.

### `dependabot.yml`
- Switch docker ecosystem commit prefix from `docker` → `chore` (non-standard `docker:` was being rejected by semantic-pr).
- Ignore major bumps for `eslint` and `@eslint/js`: ESLint 10 was opened in #91 and broke install because `eslint-plugin-react@7.x` still pins peer eslint to `<=9.7`. Hold until plugin ecosystem catches up.
- Ignore major bumps for `@types/node`: v25+ adds an experimental `localStorage` global that shadows jsdom's polyfill and breaks tests (already needed a shim in #87 — don't invite more drift).

## Test plan
- [x] YAML parses
- [ ] After merge, regenerated Dependabot PRs (#89-#94 will close + reopen) should have all CI green