### PR TITLE
chore(dependabot): block all npm majors by default

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,30 +47,12 @@ updates:
           - '@testing-library/*'
           - 'jsdom'
           - '@types/*'
+    # Block ALL npm majors by default. Majors require manual evaluation
+    # (peer dep changes, breaking config, ecosystem readiness). Dependabot
+    # handles minors and patches automatically via the groups above; to
+    # accept a major bump, do it manually with `npm install <pkg>@latest`.
     ignore:
-      - dependency-name: 'react'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-dom'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/react'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/react-dom'
-        update-types: ['version-update:semver-major']
-      # eslint v10 not yet supported by eslint-plugin-react (peer dep max ^9)
-      - dependency-name: 'eslint'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@eslint/js'
-        update-types: ['version-update:semver-major']
-      # @types/node 25+ ships experimental localStorage that broke jsdom tests
-      - dependency-name: '@types/node'
-        update-types: ['version-update:semver-major']
-      # TypeScript and lint-staged majors typically require config migration
-      - dependency-name: 'typescript'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'lint-staged'
-        update-types: ['version-update:semver-major']
-      # @vitejs/plugin-react@6 requires vite@8 (not yet released stable)
-      - dependency-name: '@vitejs/plugin-react'
+      - dependency-name: '*'
         update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
## Summary

Majors require manual evaluation (peer dep changes, breaking config, ecosystem readiness). The ignore list was growing every time Dependabot opened a new incompatible major (react, eslint, typescript, lint-staged, @vitejs/plugin-react, @types/node, vite, globals…).

Flip to deny-by-default: ignore ALL npm majors via wildcard. Minors and patches still flow automatically through the existing groups. Accept a major bump manually with `npm install <pkg>@latest` after vetting.

Net effect: simpler config, fewer broken PRs, no more whack-a-mole.

## Closing in parallel
- #105 (vite 7 → 8): would need plugin-react 6 which we already ignore.
- #106 (globals 16 → 17): breaking config change.
- #104 (plugin-react 5.0 → 5.2, minor) merges separately if green.