### PR TITLE
feat(ci): auto-deploy to Dokploy via API after CI/CD passes

### DIFF
--- a/.github/workflows/dokploy-deploy.yml
+++ b/.github/workflows/dokploy-deploy.yml
@@ -29,7 +29,10 @@ jobs:
 
     env:
       DOKPLOY_URL: http://198.12.82.184:3000
-      DOKPLOY_APPLICATION_ID: R02khAu1mJJTnpSlkiu2v
+      # Application ID for portfolio-app (service: portfolio-portfolioapp-ibhhj9)
+      # Created 2025-12-18 after the original app was deleted in the Nov 2025 incident.
+      # Verified via: SELECT "applicationId" FROM application WHERE "appName" LIKE '%portfolio%'
+      DOKPLOY_APPLICATION_ID: -t_HVHq5aV19Q0mIUuWdN
 
     steps:
       - name: Trigger Dokploy deploy

--- a/.github/workflows/dokploy-deploy.yml
+++ b/.github/workflows/dokploy-deploy.yml
@@ -1,29 +1,73 @@
-name: Deployment Notification
+name: Dokploy Auto Deploy
 
-# Simple notification workflow after CI/CD passes
-# Manual deployment via Dokploy UI: http://100.122.202.103:3000
+# Triggers a real deploy on the Dokploy instance after CI/CD passes.
+# Replaces the previous notification-only workflow that left deploys
+# to manual UI clicks.
+#
+# Configuration:
+#   - DOKPLOY_API_TOKEN: GitHub secret with a Dokploy user/api token
+#   - DOKPLOY_URL: defaults to the VPS public HTTP endpoint
+#   - DOKPLOY_APPLICATION_ID: portfolio-app id in Dokploy
+#
+# Manual trigger: workflow_dispatch (Run workflow button in Actions UI).
 
 on:
   workflow_run:
-    workflows: ["CI/CD Pipeline"]
+    workflows: ['CI/CD Pipeline']
     types: [completed]
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  notify:
+  deploy:
     runs-on: ubuntu-latest
-    # Only notify if CI/CD passed successfully
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Run on success of CI or on manual dispatch
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    env:
+      DOKPLOY_URL: http://198.12.82.184:3000
+      DOKPLOY_APPLICATION_ID: R02khAu1mJJTnpSlkiu2v
 
     steps:
-    - name: Deployment Ready Notification
-      run: |
-        echo "✅ CI/CD Pipeline passed successfully"
-        echo "🚀 Ready for deployment"
-        echo ""
-        echo "Manual deployment steps:"
-        echo "1. Access Dokploy: http://100.122.202.103:3000"
-        echo "2. Navigate to: Projects → portfolio → portfolio-app"
-        echo "3. Click 'Deploy' button"
-        echo ""
-        echo "Live site: https://tellmealex.dev"
+      - name: Trigger Dokploy deploy
+        env:
+          DOKPLOY_API_TOKEN: ${{ secrets.DOKPLOY_API_TOKEN }}
+        run: |
+          set -e
+
+          if [ -z "$DOKPLOY_API_TOKEN" ]; then
+            echo "::error::DOKPLOY_API_TOKEN secret is not set"
+            exit 1
+          fi
+
+          echo "Triggering deploy for application: $DOKPLOY_APPLICATION_ID"
+
+          response=$(curl -sS -w "\n%{http_code}" \
+            -X POST "$DOKPLOY_URL/api/trpc/application.deploy?batch=1" \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: $DOKPLOY_API_TOKEN" \
+            -H "Authorization: Bearer $DOKPLOY_API_TOKEN" \
+            -d "{\"0\":{\"json\":{\"applicationId\":\"$DOKPLOY_APPLICATION_ID\"}}}")
+
+          body=$(echo "$response" | sed '$d')
+          status=$(echo "$response" | tail -n1)
+
+          echo "HTTP $status"
+          echo "Response: $body"
+
+          if [ "$status" -ge 400 ]; then
+            echo "::error::Deploy trigger failed with HTTP $status"
+            exit 1
+          fi
+
+          # tRPC returns 200 even on app errors — check JSON for error field
+          if echo "$body" | grep -q '"error"'; then
+            echo "::error::Dokploy returned a tRPC error"
+            exit 1
+          fi
+
+          echo "Deploy triggered successfully. Monitor at $DOKPLOY_URL"
+          echo "Site: https://tellmealex.dev"


### PR DESCRIPTION
## Summary

Replaces the previous notification-only `dokploy-deploy.yml` with a real auto-deploy that calls the Dokploy tRPC API directly using the existing `DOKPLOY_API_TOKEN` secret.

## Why

After diagnosing earlier today: **0 webhook deliveries in last 6h** despite 13 commits — Dokploy's GitHub App webhook has been silently failing for ~2 months. The image actually serving `tellmealex.dev` is from `2026-03-16 09:59 UTC`.

Likely cause: webhook URL in Dokploy is `https://198.12.82.184:3000/...` but the Dokploy port 3000 only serves HTTP (HTTPS connection dies at TCP layer). Fixing the URL requires Dokploy UI access (manual). This workflow bypasses the webhook entirely.

## How

`POST /api/trpc/application.deploy?batch=1` with `Authorization: Bearer ${DOKPLOY_API_TOKEN}`. Application ID `R02khAu1mJJTnpSlkiu2v` (from `DOKPLOY-AUTO-DEPLOY-SETUP.md`).

Triggers:
- After "CI/CD Pipeline" succeeds on main
- Manual via `workflow_dispatch`

## Test plan

1. Merge this PR
2. Workflow fires off the merge commit's CI completion
3. Site `last-modified` should change within ~5 min (typical Dokploy build + nginx deploy)
4. If endpoint or auth is wrong: workflow fails loud with HTTP status + body in logs — easy to iterate
5. Manual fallback: still possible via Dokploy UI

## Pre-existing issues left untouched
- Zombie service `portfolio-portfolioapp-cjgywg` (5 months idle) — separate cleanup
- Webhook URL in Dokploy GitHub App is wrong but unused after this lands — can be fixed when convenient