### PR TITLE
fix(ci): use Dokploy app refreshToken instead of API token

### DIFF
--- a/.github/workflows/dokploy-deploy.yml
+++ b/.github/workflows/dokploy-deploy.yml
@@ -1,13 +1,13 @@
 name: Dokploy Auto Deploy
 
 # Triggers a real deploy on the Dokploy instance after CI/CD passes.
-# Replaces the previous notification-only workflow that left deploys
-# to manual UI clicks.
+# Uses the application-scoped /api/deploy/{refreshToken} endpoint — no
+# admin auth needed; the token in the URL is per-app and unguessable.
 #
 # Configuration:
-#   - DOKPLOY_API_TOKEN: GitHub secret with a Dokploy user/api token
-#   - DOKPLOY_URL: defaults to the VPS public HTTP endpoint
-#   - DOKPLOY_APPLICATION_ID: portfolio-app id in Dokploy
+#   - DOKPLOY_APP_REFRESH_TOKEN: GitHub secret with the application's
+#     refreshToken (Dokploy → app → Deployments → Deploy URL).
+#   - DOKPLOY_URL: defaults to the VPS public HTTP endpoint.
 #
 # Manual trigger: workflow_dispatch (Run workflow button in Actions UI).
 
@@ -24,53 +24,36 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # Run on success of CI or on manual dispatch
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     env:
       DOKPLOY_URL: http://198.12.82.184:3000
-      # Application ID for portfolio-app (service: portfolio-portfolioapp-ibhhj9)
-      # Created 2025-12-18 after the original app was deleted in the Nov 2025 incident.
-      # Verified via: SELECT "applicationId" FROM application WHERE "appName" LIKE '%portfolio%'
-      DOKPLOY_APPLICATION_ID: -t_HVHq5aV19Q0mIUuWdN
 
     steps:
       - name: Trigger Dokploy deploy
         env:
-          DOKPLOY_API_TOKEN: ${{ secrets.DOKPLOY_API_TOKEN }}
+          DOKPLOY_APP_REFRESH_TOKEN: ${{ secrets.DOKPLOY_APP_REFRESH_TOKEN }}
         run: |
           set -e
 
-          if [ -z "$DOKPLOY_API_TOKEN" ]; then
-            echo "::error::DOKPLOY_API_TOKEN secret is not set"
+          if [ -z "$DOKPLOY_APP_REFRESH_TOKEN" ]; then
+            echo "::error::DOKPLOY_APP_REFRESH_TOKEN secret is not set"
             exit 1
           fi
-
-          echo "Triggering deploy for application: $DOKPLOY_APPLICATION_ID"
 
           response=$(curl -sS -w "\n%{http_code}" \
-            -X POST "$DOKPLOY_URL/api/trpc/application.deploy?batch=1" \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: $DOKPLOY_API_TOKEN" \
-            -H "Authorization: Bearer $DOKPLOY_API_TOKEN" \
-            -d "{\"0\":{\"json\":{\"applicationId\":\"$DOKPLOY_APPLICATION_ID\"}}}")
+            -X POST "$DOKPLOY_URL/api/deploy/$DOKPLOY_APP_REFRESH_TOKEN")
 
           body=$(echo "$response" | sed '$d')
-          status=$(echo "$response" | tail -n1)
+          http_status=$(echo "$response" | tail -n1)
 
-          echo "HTTP $status"
+          echo "HTTP $http_status"
           echo "Response: $body"
 
-          if [ "$status" -ge 400 ]; then
-            echo "::error::Deploy trigger failed with HTTP $status"
+          if [ "$http_status" -ge 400 ]; then
+            echo "::error::Deploy trigger failed with HTTP $http_status"
             exit 1
           fi
 
-          # tRPC returns 200 even on app errors — check JSON for error field
-          if echo "$body" | grep -q '"error"'; then
-            echo "::error::Dokploy returned a tRPC error"
-            exit 1
-          fi
-
-          echo "Deploy triggered successfully. Monitor at $DOKPLOY_URL"
+          echo "Deploy triggered. Build runs in Dokploy (~2-5 min)."
           echo "Site: https://tellmealex.dev"


### PR DESCRIPTION
## Summary

`DOKPLOY_API_TOKEN` returned 401 in the first deploy attempt — the token is either revoked or expired (created 2025-12-14).

Switching to the per-application `refreshToken` endpoint instead. That endpoint:
- Doesn't need any auth headers — the unguessable token in the URL path IS the credential
- Is the same mechanism Dokploy uses for its own "Deploy URL" CI hook
- One-shot pull, no admin scope

Endpoint: `POST /api/deploy/{refreshToken}`
Secret: `DOKPLOY_APP_REFRESH_TOKEN` (extracted from Dokploy DB and stored as GitHub secret)