### PR TITLE
fix(docker): healthcheck use 127.0.0.1 explicit (IPv6 connect refused)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ EXPOSE 80
 # - start-period: allow 5 seconds for startup
 # - retries: 3 failed checks = unhealthy
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --quiet --tries=1 --spider http://localhost/ || exit 1
+    CMD wget --quiet --tries=1 --spider http://127.0.0.1/ || exit 1
 
 # Start Nginx in foreground mode
 # This keeps the container running and allows proper signal handling


### PR DESCRIPTION
## Summary
- BusyBox \`wget\` in \`nginx:alpine\` defaults to IPv6 (\`[::1]:80\`) when resolving \`localhost\`. nginx only listens on IPv4, so the healthcheck got \`Connection refused\` and Swarm killed every new container after ~67s.
- Root cause of the paused rolling update that left tellmealex.dev serving the March build for hours despite a successful GH Actions deploy.
- Fix: target \`http://127.0.0.1/\` explicitly.

## Verification
Inside the running image:
- \`wget --spider http://localhost/\` → \`can't connect to [::1]:80\`, exit 1
- \`wget --spider http://127.0.0.1/\` → exit 0

The earlier \`curl -f http://localhost/\` (PR #113 dropped) worked because curl falls back to IPv4 transparently. wget (BusyBox) does not.

## Test plan
- [x] Reproduced failure in standalone container of current image
- [x] Verified 127.0.0.1 fix succeeds
- [ ] CI/CD pipeline passes
- [ ] Auto-deploy triggers, Swarm rolling update completes, site \`last-modified\` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)